### PR TITLE
Fix GraphHopper OSM map data fallback exception

### DIFF
--- a/src/main/java/com/example/securityrouting/GraphHopperConfig.java
+++ b/src/main/java/com/example/securityrouting/GraphHopperConfig.java
@@ -16,10 +16,16 @@ public class GraphHopperConfig {
     public GraphHopper graphHopper() {
         GraphHopper hopper = new GraphHopper();
 
-        if (new File("map-data.osm.bz2").exists()) {
+        File bz2 = new File("map-data.osm.bz2");
+        File osm = new File("map-data.osm");
+        File cache = new File("graph-cache");
+
+        if (bz2.exists()) {
             hopper.setOSMFile("map-data.osm.bz2");
-        } else {
+        } else if (osm.exists()) {
             hopper.setOSMFile("map-data.osm");
+        } else if (!cache.exists()) {
+            throw new IllegalStateException("No OSM map data file found. Please place map-data.osm or map-data.osm.bz2 in the application directory.");
         }
 
         hopper.setGraphHopperLocation("graph-cache");


### PR DESCRIPTION
Fixed the bug where GraphHopper failed to start with a confusing exception if `map-data.osm` was missing but a cache was present, or if the user provided an incorrectly named file.

This was caused by the fallback logic unconditionally setting `map-data.osm` regardless of whether the file actually existed. The fix properly checks for file existence before attempting to set the file on the `GraphHopper` instance, and provides a much more descriptive exception if no OSM map data file can be found and there is no pre-existing cache to load from.

---
*PR created automatically by Jules for task [11429431615540248596](https://jules.google.com/task/11429431615540248596) started by @tyronechrisharris*