### PR TITLE
Fix Lombok compilation error in maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
Explicitly configures `maven-compiler-plugin` in `pom.xml` to include `lombok` in its `annotationProcessorPaths`. This fixes compilation issues on newer environments where Lombok's annotation processing must be explicitly enabled.

---
*PR created automatically by Jules for task [5564009569431361175](https://jules.google.com/task/5564009569431361175) started by @tyronechrisharris*