### PR TITLE
Add workflow_dispatch to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release Builds
 on:
   release:
     types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   test_and_build:


### PR DESCRIPTION
Added a manual trigger (`workflow_dispatch`) to `.github/workflows/release.yml` so that release builds can be started manually from the GitHub UI. Also added the necessary `permissions: contents: write` block to ensure the workflow has sufficient permissions to publish release assets.

---
*PR created automatically by Jules for task [4182173690276170079](https://jules.google.com/task/4182173690276170079) started by @tyronechrisharris*