### PR TITLE
build: Update macOS artifact architecture name to ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             asset_name: secure-route-linux-amd64
           - os: macos-latest
             artifact_name: secure-route-mac
-            asset_name: secure-route-macos-amd64
+            asset_name: secure-route-macos-arm64
           - os: windows-latest
             artifact_name: secure-route.exe
             asset_name: secure-route-windows-amd64.exe


### PR DESCRIPTION
Update the GitHub Actions release workflow to use `-arm64` instead of `-amd64` in the macOS artifact name. Since the `macos-latest` runner uses Apple Silicon (M-series / ARM64 processors) by default, the native build produces an ARM64 binary. The asset name has been updated to accurately reflect the architecture, while leaving Linux and Windows appropriately configured for AMD64.

---
*PR created automatically by Jules for task [5873917684728247336](https://jules.google.com/task/5873917684728247336) started by @tyronechrisharris*