### PR TITLE
Fix: README architecture docs and add M4 Max release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,31 @@ permissions:
 
 jobs:
   test_and_build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.asset_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
+          # Target 1: Linux
           - os: ubuntu-latest
             artifact_name: secure-route-linux
             asset_name: secure-route-linux-amd64
+            rustflags: ''
+          # Target 2: Generic Mac (M1/M2/M3 compatible)
           - os: macos-latest
             artifact_name: secure-route-mac
             asset_name: secure-route-macos-arm64
+            rustflags: ''
+          # Target 3: Optimized Mac M4 Max
+          - os: macos-latest
+            artifact_name: secure-route-mac-m4
+            asset_name: secure-route-macos-m4-max
+            rustflags: '-C target-cpu=apple-m4'
+          # Target 4: Windows
           - os: windows-latest
             artifact_name: secure-route.exe
             asset_name: secure-route-windows-amd64.exe
+            rustflags: ''
 
     steps:
       - name: Checkout repository
@@ -46,7 +56,7 @@ jobs:
       - name: Build release binary
         run: cargo build --release
         env:
-          RUSTFLAGS: ${{ matrix.os == 'macos-latest' && '-C target-cpu=native' || '' }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
 
       - name: Rename and Prepare Asset (Linux/Mac)
         if: matrix.os != 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A highly performant, memory-safe, purely offline routing engine natively built in Rust, replacing the legacy Java backend.
 
 ## Features
-- **Zero-Copy Graph Serialization:** Processes large `.osm.pbf` files directly into a memory-mapped `rkyv` `.graph` file to load into RAM in less than a few milliseconds.
+- **Fast Graph Serialization:** Processes massive `.osm.pbf` files and serializes the Contraction Hierarchies routing graph using bincode into a `.graph` file, allowing initialization in milliseconds.
 - **Parallel Parsing:** Utilizes `osmpbfreader` and `rayon` to digest planet-scale graphs effortlessly.
 - **Fast Routing:** Implements Dijkstra / Contraction Hierarchies compatible routing logic mimicking GraphHopper 9.0's CustomModel.
 - **Offline PMTiles Map Rendering:** Connects via Axum.


### PR DESCRIPTION
This PR corrects documentation drift in the README and enhances the CI/CD pipeline. 

The README now accurately reflects that the project uses bincode for graph serialization, following the migration to Contraction Hierarchies. 

The release workflow has been updated to explicitly target various architectures, including a specialized build for the M4 Max chip (apple-m4). This replaces the previous use of 'target-cpu=native', which was problematic on GitHub's hosted M1 runners when aiming for higher-end target optimizations.

Fixes #22

---
*PR created automatically by Jules for task [1098839466193332793](https://jules.google.com/task/1098839466193332793) started by @tyronechrisharris*