### PR TITLE
Unpack Edge Geometry in API Response

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,8 +12,6 @@ use std::sync::Mutex;
 const ROUTABLE_NODES: TableDefinition<i64, ()> = TableDefinition::new("routable_nodes");
 const NODE_COORDS: TableDefinition<i64, [f64; 2]> = TableDefinition::new("node_coords");
 const OSM_TO_INTERNAL: TableDefinition<i64, u64> = TableDefinition::new("osm_to_internal");
-// Key: (Source Node ID, Target Node ID), Value: Serialized Vec<[f64; 2]>
-const EDGE_GEOMETRY: TableDefinition<(u64, u64), Vec<u8>> = TableDefinition::new("edge_geometry");
 const NODE_DEGREES: TableDefinition<i64, u32> = TableDefinition::new("node_degrees");
 
 pub fn build_graph(pbf_path: &str, out_path: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -194,7 +192,7 @@ pub fn build_graph(pbf_path: &str, out_path: &str) -> Result<(), Box<dyn std::er
     let mut input_graph = InputGraph::new();
     let write_txn = db.begin_write()?;
     {
-        let mut edge_geo_table = write_txn.open_table(EDGE_GEOMETRY)?;
+        let mut edge_geo_table = write_txn.open_table(crate::graph::EDGE_GEOMETRY)?;
         for (s, t, w, is_ow) in input_graph_edges.into_inner().unwrap() {
             input_graph.add_edge(s as usize, t as usize, w);
             if !is_ow {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,8 @@
 use fast_paths::FastGraph;
 use serde::{Deserialize, Serialize};
+use redb::TableDefinition;
+
+pub const EDGE_GEOMETRY: TableDefinition<(u64, u64), Vec<u8>> = TableDefinition::new("edge_geometry");
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct SecurityAsset {

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ struct Asset;
 
 pub struct AppState {
     pub graph_data: GraphData,
+    pub db: redb::Database,
 }
 
 #[derive(Deserialize)]
@@ -61,8 +62,13 @@ pub async fn run_server(graph_path: String, pmtiles_path: String, bind: String) 
     let graph_bytes = std::fs::read(&graph_path).expect("Failed to read graph file");
     let graph_data: GraphData = bincode::deserialize(&graph_bytes).expect("Failed to deserialize graph data via bincode");
 
+    let cache_path = format!("{}.redb", graph_path);
+    println!("Opening redb database at {}...", cache_path);
+    let db = redb::Database::open(&cache_path).expect("Failed to open redb database");
+
     let state = Arc::new(AppState {
         graph_data,
+        db,
     });
 
     // ServeFile correctly implements HTTP Range requests natively which map.pmtiles requires.
@@ -121,9 +127,28 @@ async fn calculate_route(
 
     let mut coords = Vec::new();
 
-    for i in 0..path_ids.len() {
-        let n = &state.graph_data.nodes[path_ids[i]];
-        coords.push(vec![n.lon, n.lat]);
+    if !path_ids.is_empty() {
+        let read_txn = state.db.begin_read().expect("Failed to begin read transaction");
+        let edge_geo_table = read_txn.open_table(crate::graph::EDGE_GEOMETRY).expect("Failed to open edge geometry table");
+
+        // Add first node
+        let first_node = &state.graph_data.nodes[path_ids[0]];
+        coords.push(vec![first_node.lon, first_node.lat]);
+
+        for i in 0..path_ids.len() - 1 {
+            let u = path_ids[i] as u64;
+            let v = path_ids[i + 1] as u64;
+
+            if let Ok(Some(geo_bytes)) = edge_geo_table.get((u, v)) {
+                let points: Vec<[f64; 2]> = bincode::deserialize(geo_bytes.value().as_slice()).unwrap();
+                for p in points {
+                    coords.push(vec![p[1], p[0]]); // Swap to [lon, lat]
+                }
+            }
+
+            let next_node = &state.graph_data.nodes[path_ids[i + 1]];
+            coords.push(vec![next_node.lon, next_node.lat]);
+        }
     }
 
     // A real system would sum real physical distances. Here we just return an approximation.


### PR DESCRIPTION
This change updates the Axum routing handler in `server.rs` to connect to the read-only `.redb` cache generated by the builder. When a route is calculated, the server now looks up the hidden shape points for each segment in the `EDGE_GEOMETRY` table and "unpacks" them into the final JSON response. This ensures that the frontend can draw the actual curves of the roads instead of straight lines between intersections.

Key changes:
1.  **Shared Table Definition**: The `EDGE_GEOMETRY` table definition was moved to `src/graph.rs` so it can be accessed by both the builder and the server.
2.  **Server State**: `AppState` now holds a `redb::Database` instance, which is opened during server initialization in `run_server`.
3.  **Unpacking Logic**: The `calculate_route` handler now iterates through the path IDs as adjacent pairs, querying the `EDGE_GEOMETRY` table for intermediate shape points. These points are deserialized and added to the response coordinate list.
4.  **Coordinate Format**: Points are correctly swapped from `[lat, lon]` (as stored in the DB) to `[lon, lat]` (as expected by the API).
5.  **Robustness**: The logic handles cases where no geometry is found for a segment by simply using the intersection coordinates, ensuring path continuity.

Fixes #29

---
*PR created automatically by Jules for task [1636511267668554003](https://jules.google.com/task/1636511267668554003) started by @tyronechrisharris*