### PR TITLE
Fix Leaflet PMTiles Initialization & Cascading UI Errors

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,9 +1,11 @@
-const protocol = new pmtiles.Protocol();
-L.addProtocol('pmtiles', protocol.tile);
-
+// 1. Initialize the Leaflet map FIRST
 var map = L.map('map').setView([51.505, -0.09], 13);
 
-L.tileLayer(`pmtiles://${window.location.host}/map.pmtiles`, {
+// 2. Initialize the PMTiles instance pointing to the dynamic Axum server host
+const p = new pmtiles.PMTiles(`http://${window.location.host}/map.pmtiles`);
+
+// 3. Add the PMTiles layer using the dedicated Leaflet integration function
+pmtiles.leafletRasterLayer(p, {
     maxZoom: 19,
     attribution: '© OpenStreetMap contributors'
 }).addTo(map);


### PR DESCRIPTION
This change fixes a fatal error on frontend load where `L.addProtocol` was being called on the Leaflet `L` object, which is not supported. This crash prevented the `map` and `layers` objects from being initialized, leading to further errors when interacting with UI elements (like layer toggles) that depend on those objects. 

The fix involves using the correct `pmtiles.leafletRasterLayer` helper function as required for Leaflet-specific PMTiles integration. Frontend verification confirmed that the map now initializes correctly and UI interactions no longer throw errors.

Fixes #46

---
*PR created automatically by Jules for task [1735433329761196703](https://jules.google.com/task/1735433329761196703) started by @tyronechrisharris*