### PR TITLE
Implement Vector Tile Renderer for PMTiles (MVT)

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,13 +1,10 @@
 // 1. Initialize the Leaflet map FIRST
 var map = L.map('map').setView([51.505, -0.09], 13);
 
-// 2. Initialize the PMTiles instance pointing to the dynamic Axum server host
-const p = new pmtiles.PMTiles(`http://${window.location.host}/map.pmtiles`);
-
-// 3. Add the PMTiles layer using the dedicated Leaflet integration function
-pmtiles.leafletRasterLayer(p, {
-    maxZoom: 19,
-    attribution: '© OpenStreetMap contributors'
+// 2. Add the Vector PMTiles layer using the Protomaps Leaflet renderer
+protomapsL.leafletLayer({
+    url: `http://${window.location.host}/map.pmtiles`,
+    theme: 'light' // Automatically applies a clean styling theme to the raw vector data
 }).addTo(map);
 
 var layers = {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <link rel="stylesheet" href="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.css" />
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
-    <script src="https://unpkg.com/pmtiles@3.0.6/dist/pmtiles.js"></script>
     <style>
         body { margin: 0; padding: 0; display: flex; font-family: 'Segoe UI', sans-serif; height: 100vh; }
         #sidebar { width: 350px; background: #1a1a1a; color: #f0f0f0; padding: 20px; overflow-y: auto; display: flex; flex-direction: column; gap: 15px; box-shadow: 2px 0 5px rgba(0,0,0,0.5); z-index: 1000; }
@@ -161,6 +160,7 @@
 </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/protomaps-leaflet@4.1.0/dist/protomaps-leaflet.min.js"></script>
     <script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.min.js"></script>
 <script src="app.js"></script>
 </body>


### PR DESCRIPTION
The application previously failed to render map data because it was attempting to use a raster renderer (leafletRasterLayer) for a PMTiles archive containing vector tiles (MVT).

I have replaced the `pmtiles` library with `protomaps-leaflet` in `index.html` and updated the map initialization in `app.js` to use `protomapsL.leafletLayer`. This allows the application to correctly parse and render vector data from the PMTiles archive onto the Leaflet map using the 'light' theme.

Fixes #48

---
*PR created automatically by Jules for task [5178210719334872270](https://jules.google.com/task/5178210719334872270) started by @tyronechrisharris*