### PR TITLE
Enforce Absolute URL for PMTiles Web Worker and Update Default Map View

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,12 +1,13 @@
 // 1. Initialize the Leaflet map FIRST
-// Default to the Manila operational zone (Zoom Level 13)
-// Note: Swap to [36.0104, -84.2696] for local Oak Ridge testing
-var map = L.map('map').setView([36.0104, -84.2696], 13);
+var map = L.map('map').setView([14.5995, 120.9842], 13); // Manila Default
 
-// 2. Add the Vector PMTiles layer using the Protomaps Leaflet renderer
+// 2. Construct a strict Absolute URL for the Web Worker
+const mapUrl = `${window.location.origin}/map.pmtiles`;
+
+// 3. Add the Vector PMTiles layer
 protomapsL.leafletLayer({
-    url: '/map.pmtiles',
-    theme: 'light' // Automatically applies a clean styling theme to the raw vector data
+    url: mapUrl,
+    theme: 'light'
 }).addTo(map);
 
 var layers = {


### PR DESCRIPTION
The PMTiles Web Worker requires an absolute URL for proper origin resolution and 206 Partial Content requests. This PR updates the Leaflet map initialization in `app.js` to construct and use an absolute URL. Additionally, the default map view is set to the Manila operational zone.

Fixes #54

---
*PR created automatically by Jules for task [1463834799284352137](https://jules.google.com/task/1463834799284352137) started by @tyronechrisharris*